### PR TITLE
modify max_completion_tokens value

### DIFF
--- a/types/openai.ts
+++ b/types/openai.ts
@@ -6,6 +6,7 @@ export interface OpenAIModel {
   maxLength: number; // maximum length of a message
   tokenLimit: number;
   requestLimit: number;
+  completionTokenLimit: number;
 }
 
 export enum OpenAIModelID {
@@ -25,6 +26,7 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     maxLength: 380000,
     tokenLimit: 128000,
     requestLimit: 95000,
+    completionTokenLimit: 16384,
   },
   [OpenAIModelID.GPT_4_O_MINI]: {
     id: OpenAIModelID.GPT_4_O_MINI,
@@ -32,6 +34,7 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     maxLength: 380000,
     tokenLimit: 128000,
     requestLimit: 95000,
+    completionTokenLimit: 16384,
   },
   [OpenAIModelID.GPT_4_O_1_PREVIEW]: {
     id: OpenAIModelID.GPT_4_O_1_PREVIEW,
@@ -39,6 +42,7 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     maxLength: 380000,
     tokenLimit: 128000,
     requestLimit: 95000,
+    completionTokenLimit: 16384,
   },
   [OpenAIModelID.GPT_4_O_1_MINI]: {
     id: OpenAIModelID.GPT_4_O_1_MINI,
@@ -46,5 +50,6 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     maxLength: 380000,
     tokenLimit: 128000,
     requestLimit: 95000,
+    completionTokenLimit: 16384,
   },
 };

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -65,7 +65,7 @@ export const OpenAIStream = async (
           : [{ role: 'system', content: systemPrompt }]),
         ...messages,
       ],
-      max_completion_tokens: (model.tokenLimit - tokenCount),
+      max_completion_tokens: model.completionTokenLimit,
       temperature: isBeta(model.id) ? 1 : temperature,
       stream: isStream,
     }),


### PR DESCRIPTION
This pull request introduces a new property, `completionTokenLimit`, to the `OpenAIModel` interface and updates related logic to use this new property. The changes ensure that the completion token limit is properly defined and utilized across the codebase.

### Enhancements to OpenAI Model Interface:

* [`types/openai.ts`](diffhunk://#diff-cd8395a5ad1236cc8b3a912ea7aa0aeaf35491f9ffa169a71ff9dcc8b25e366dR9): Added `completionTokenLimit` to the `OpenAIModel` interface and updated the `OpenAIModels` object to include this new property for each model. [[1]](diffhunk://#diff-cd8395a5ad1236cc8b3a912ea7aa0aeaf35491f9ffa169a71ff9dcc8b25e366dR9) [[2]](diffhunk://#diff-cd8395a5ad1236cc8b3a912ea7aa0aeaf35491f9ffa169a71ff9dcc8b25e366dR29-R53)

### Updates to Token Limit Logic:

* [`utils/server/index.ts`](diffhunk://#diff-7eb77d0ad2fa7d18b998fb085a8edd460f4828a5ea106d9035d372406838beaeL68-R68): Modified the `OpenAIStream` function to use `model.completionTokenLimit` instead of calculating the completion tokens dynamically.


max_completion_tokens の値として古いオプションの max_tokens と同様の設定がなされていたが、max_completion_tokens は completion で出力される token の limit なのでそれに合うように変更。

```
max_completion_tokens
integer or null

Optional
An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).
```